### PR TITLE
println NREPL port instead of logging out

### DIFF
--- a/src/clojupyter/kernel/cljsrv.clj
+++ b/src/clojupyter/kernel/cljsrv.clj
@@ -185,5 +185,5 @@
         nrepl-client        (nrepl/client-session nrepl-base-client)
         nrepl-sockaddr      (.getLocalSocketAddress ^java.net.ServerSocket (:server-socket nrepl-server))
         cljsrv          (->CljSrv nrepl-server nrepl-client nrepl-sockaddr (atom false))]
-    (log/info (str "Started NREPL server: tcp:/" nrepl-sockaddr "."))
+    (println (str "Started NREPL server: tcp:/" nrepl-sockaddr "."))
     cljsrv))


### PR DESCRIPTION
I find this so useful that I think it should be "printed" instead of logged. I use clojupyter in devcontainer, and idealy I don't  want to change logging config only to see the nrepl port